### PR TITLE
Adiciona serviço para otimização de imagens

### DIFF
--- a/sites/bonde/docker-compose.yml
+++ b/sites/bonde/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       - imaginary_data:/mnt/data
     environment:
        PORT: 9000
+       DEBUG: ${IMAGINARY_DEBUG-:*}
     command:
       -mount /mnt/data
       -enable-url-source

--- a/sites/bonde/docker-compose.yml
+++ b/sites/bonde/docker-compose.yml
@@ -35,6 +35,31 @@ services:
       - traefik.http.routers.public-catchall-http.entrypoints=web
       - traefik.http.routers.public-catchall-http.priority=1
 
+  imaginary:
+    image: h2non/imaginary:latest
+    volumes:
+      - imaginary_data:/mnt/data
+    environment:
+       PORT: 9000
+    command:
+      -mount /mnt/data
+      -enable-url-source
+      -cors
+      -gzip
+      -allowed-origins ${IMAGINARY_ALLOWED_ORIGINS:-https://s3.amazonaws.com/hub-central/uploads/}
+      -http-cache-ttl 31556926
+      -enable-placeholder
+    restart: "${DOCKER_RESTART_POLICY:-unless-stopped}"
+    labels:
+      - traefik.enable=true
+      - traefik.http.services.imaginary.loadbalancer.server.port=9000
+      - traefik.http.routers.imaginary.tls=true
+      - traefik.http.routers.imaginary.tls.certresolver=myresolver
+
+volumes:
+  imaginary_data:
+    driver: local
+
 # Todos os serviços devem pertencer a mesma rede para serem descobertos pelo Traefik
 networks:
   default:

--- a/sites/bonde/docker-compose.yml
+++ b/sites/bonde/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - REACT_APP_DOMAIN_API_REST=${PUBLIC_REST_API:-http://api-rest.bonde.devel}
       - REACT_APP_DOMAIN_PUBLIC=${DEFAULT_DOMAIN_RULE:-bonde.devel}
       - REACT_APP_ACTIVE_API_CACHE=${ACTIVE_API_CACHE:-false}
+      - REACT_APP_DOMAIN_IMAGINARY=${PUBLIC_DOMAIN_IMAGINARY:-http://imaginary.bonde.devel}
     healthcheck:
       test: "${DOCKER_WEB_HEALTHCHECK_TEST:-wget -qO- localhost:3000/api/ping}"
       interval: "60s"

--- a/sites/bonde/docker-compose.yml
+++ b/sites/bonde/docker-compose.yml
@@ -46,7 +46,6 @@ services:
       -mount /mnt/data
       -enable-url-source
       -cors
-      -gzip
       -allowed-origins ${IMAGINARY_ALLOWED_ORIGINS:-https://s3.amazonaws.com/hub-central/uploads/}
       -http-cache-ttl 31556926
       -enable-placeholder


### PR DESCRIPTION
**Contexto**

O Bonde já utilizada um serviço de otimização de imagens antes da migração de servidores, com objetivo de deixar a arquitetura mais simples possível esse serviço havia sido removido, mas isso gerou um problema na parte de edição da página.

Objetivo dessa contribuição é adicionar o serviço que é essencial para funcionalidade na arquitetura e aplicar o uso dela nas versões necessárias (modo edição e modo público).

https://github.com/h2non/imaginary